### PR TITLE
Fix KeyError on most recent python-markdown

### DIFF
--- a/pykwiki/ext/post.py
+++ b/pykwiki/ext/post.py
@@ -79,8 +79,8 @@ class PostExtension(markdown.Extension):
         md.inlinePatterns['pykwiki.post.section_start'] = SectionStartPattern(SEC_START_RE, md)
         md.inlinePatterns['pykwiki.post.section_end'] = SectionEndPattern(SEC_END_RE, md)
 
-def makeExtension(configs={}):
-    return PostExtension(configs=configs)
+def makeExtension(**kwargs):
+    return PostExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest

--- a/pykwiki/ext/post.py
+++ b/pykwiki/ext/post.py
@@ -1,7 +1,7 @@
 import markdown
 from pykwiki.core import conf, Post
 
-POST_RE = r'(\[\[([a-zA-Z0-9]+.*?)\]\])' 
+POST_RE = r'(\[\[([a-zA-Z0-9]+.*?)\]\])'
 SEC_START_RE = r'(\{section:(.*?)\})'
 SEC_END_RE = r'(\{endsection\})'
 
@@ -33,7 +33,7 @@ class PostPattern(markdown.inlinepatterns.Pattern):
 
         # For [[page:link]]
         if action == 'link':
-            url = '%s/%s'%(conf.web_prefix, 
+            url = '%s/%s'%(conf.web_prefix,
                 post.replace(conf.source_ext, conf.target_ext))
             el = markdown.util.etree.Element("a")
             el.set('href', url)
@@ -53,7 +53,7 @@ class PostPattern(markdown.inlinepatterns.Pattern):
         # For [[page:blurb]]
         if action == 'blurb':
             return pg.blurb
-        
+
         # For [[page:title]]
         if action == 'title':
             return pg.title
@@ -62,7 +62,7 @@ class PostPattern(markdown.inlinepatterns.Pattern):
         if action == 'section':
             if not extra:
                 return 'No section name given'
-            sec = pg.get_section(extra, raw=False) 
+            sec = pg.get_section(extra, raw=False)
             if not sec:
                 return 'Cannot find section: %s'%(extra)
             el = markdown.util.etree.Element("div")

--- a/pykwiki/ext/tpl.py
+++ b/pykwiki/ext/tpl.py
@@ -43,8 +43,8 @@ class TPLExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):
         md.preprocessors.add('pykwiki.tpl', TPLPreprocessor(md), '_begin')
 
-def makeExtension(configs={}):
-    return TPLExtension(configs=configs)
+def makeExtension(**kwargs):
+    return TPLExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest

--- a/pykwiki/ext/tpl.py
+++ b/pykwiki/ext/tpl.py
@@ -28,14 +28,14 @@ class TPLPreprocessor(markdown.preprocessors.Preprocessor):
 
             if not tpl.endswith(conf.template_ext):
                 tpl = tpl + conf.template_ext
-            
+
             d = {}
             if args:
-                d = yaml.load(args)           
-            
+                d = yaml.load(args)
+
             html = render_tpl(tpl, **d)
-            text = pat.sub(html, text, 1)        
- 
+            text = pat.sub(html, text, 1)
+
         return text.split('\n')
 
 class TPLExtension(markdown.Extension):

--- a/pykwiki/ext/uml.py
+++ b/pykwiki/ext/uml.py
@@ -5,7 +5,6 @@ import jinja2
 import re
 
 UML_RE = r'^(\{uml\})(.+?)(\{enduml\})'
-PLANT_UML_CONFIGS = {}
 
 class UMLPreprocessor(markdown.preprocessors.Preprocessor):
 
@@ -45,9 +44,8 @@ class UMLExtension(markdown.Extension):
         md.plant_options = self.config
         md.preprocessors.add('pykwiki.uml', UMLPreprocessor(md), '_begin')
 
-def makeExtension(**configs):
-    PLANT_UML_CONFIGS = configs
-    return UMLExtension(**configs)
+def makeExtension(**kwargs):
+    return UMLExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest

--- a/pykwiki/ext/uml.py
+++ b/pykwiki/ext/uml.py
@@ -18,8 +18,8 @@ class UMLPreprocessor(markdown.preprocessors.Preprocessor):
         except:
             print("WARNING: Plantuml not installed for this python version: ext.uml disabled.")
             return lines
-    
-        
+
+
         text = '\n'.join(lines)
         pat = re.compile(UML_RE, re.DOTALL|re.M)
         ms = pat.findall(text)
@@ -31,8 +31,8 @@ class UMLPreprocessor(markdown.preprocessors.Preprocessor):
         for m in ms:
             uml = m[1]
             url = puml.get_url(uml)
-            text = pat.sub('<img src="%s"/>'%(url), text, 1)  
- 
+            text = pat.sub('<img src="%s"/>'%(url), text, 1)
+
         return text.split('\n')
 
 class UMLExtension(markdown.Extension):


### PR DESCRIPTION
This fixes a `KeyError` on the most recent `python-markdown`

```
In [4]: %run /home/evan/resources/pykwiki/pykwiki/scripts/pykwiki cache -f                      
/home/evan/resources/pykwiki/pykwiki/core.py:269: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(txt)
========================================
INFO:pykwiki:========================================
Caching source posts
INFO:pykwiki:Caching source posts
/home/evan/resources/pykwiki/pykwiki/core.py:837: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  self._conf = yaml.load(m.group(1))
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/resources/pykwiki/pykwiki/scripts/pykwiki in <module>
    391     elif args.command == 'cache':
    392         load_config(args)
--> 393         command_cache(args)
    394 
    395 

~/resources/pykwiki/pykwiki/scripts/pykwiki in command_cache(args)
    240         force = True
    241     logger.info('Caching source posts')
--> 242     num_cached = ctrl.cache_posts(plist, force=force)
    243     logger.info('='*40)
    244     if num_cached > 0:

~/resources/pykwiki/pykwiki/core.py in cache_posts(self, plist, force)
    306                     continue
    307             cached += 1
--> 308             pg.save()
    309 
    310         return cached

~/resources/pykwiki/pykwiki/core.py in save(self)
    787 
    788         pc = self.conf
--> 789         tt = self.target_text
    790         conf.logger.debug('Saving to: %s'%(self.target_path))
    791         html = render_theme_template(conf.post_tpl, post=self)

~/resources/pykwiki/pykwiki/core.py in target_text(self)
    909             return self._target_text
    910         conf.logger.debug('Caching: %s'%(self.source_fname))
--> 911         md = markdown.Markdown(extensions=conf.markdown_exts)
    912         html = md.convert(self.source_text)
    913         #self._toc = md.toc

~/resources/venv3/lib/python3.6/site-packages/markdown/core.py in __init__(self, **kwargs)
     98         self.htmlStash = util.HtmlStash()
     99         self.registerExtensions(extensions=kwargs.get('extensions', []),
--> 100                                 configs=kwargs.get('extension_configs', {}))
    101         self.set_output_format(kwargs.get('output_format', 'xhtml'))
    102         self.reset()

~/resources/venv3/lib/python3.6/site-packages/markdown/core.py in registerExtensions(self, extensions, configs)
    124         for ext in extensions:
    125             if isinstance(ext, util.string_type):
--> 126                 ext = self.build_extension(ext, configs.get(ext, {}))
    127             if isinstance(ext, Extension):
    128                 ext._extendMarkdown(self)

~/resources/venv3/lib/python3.6/site-packages/markdown/core.py in build_extension(self, ext_name, configs)
    179             # Expect  makeExtension() function to return a class.
    180             try:
--> 181                 return module.makeExtension(**configs)
    182             except AttributeError as e:
    183                 message = e.args[0]

~/resources/pykwiki/pykwiki/ext/tpl.py in makeExtension(configs)
     45 
     46 def makeExtension(configs={}):
---> 47     return TPLExtension(configs=configs)
     48 
     49 if __name__ == "__main__":

~/resources/venv3/lib/python3.6/site-packages/markdown/extensions/__init__.py in __init__(self, **kwargs)
     40     def __init__(self, **kwargs):
     41         """ Initiate Extension and set up configs. """
---> 42         self.setConfigs(kwargs)
     43 
     44     def getConfig(self, key, default=''):

~/resources/venv3/lib/python3.6/site-packages/markdown/extensions/__init__.py in setConfigs(self, items)
     71             items = items.items()
     72         for key, value in items:
---> 73             self.setConfig(key, value)
     74 
     75     def _extendMarkdown(self, *args):

~/resources/venv3/lib/python3.6/site-packages/markdown/extensions/__init__.py in setConfig(self, key, value)
     59     def setConfig(self, key, value):
     60         """ Set a config setting for `key` with the given `value`. """
---> 61         if isinstance(self.config[key][0], bool):
     62             value = parseBoolValue(value)
     63         if self.config[key][0] is None:

KeyError: 'configs'
```