### PR TITLE
Add support for metadata separated by ---

### DIFF
--- a/pykwiki/core.py
+++ b/pykwiki/core.py
@@ -112,6 +112,7 @@ class Config(object):
     ]
     # The regex to grab post data blocks
     post_conf_re = re.compile('^\[\[(.*?)\]\]', re.DOTALL)
+    post_conf_re2 = re.compile('^---(.*?)\\n---', re.DOTALL)
     post_toc_re = re.compile('^\s{0,3}\[TOC\]', re.MULTILINE)
     blurb_max = 50
     home_page = 'index'
@@ -827,7 +828,10 @@ class Post(object):
         if self._conf:
             return self._conf
 
-        m = conf.post_conf_re.search(self.source_text)
+        m = (
+            conf.post_conf_re.search(self.source_text) or
+            conf.post_conf_re2.search(self.source_text)
+        )
         if not m:
             conf.logger.warning('No post config specified for %s'%(self.source_fname))
             self._conf = {'foo':True}

--- a/pykwiki/ext/post.py
+++ b/pykwiki/ext/post.py
@@ -79,8 +79,8 @@ class PostExtension(markdown.Extension):
         md.inlinePatterns['pykwiki.post.section_start'] = SectionStartPattern(SEC_START_RE, md)
         md.inlinePatterns['pykwiki.post.section_end'] = SectionEndPattern(SEC_END_RE, md)
 
-def makeExtension(configs={}):
-    return PostExtension(configs=configs)
+def makeExtension(**kwargs):
+    return PostExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest

--- a/pykwiki/ext/post.py
+++ b/pykwiki/ext/post.py
@@ -1,7 +1,7 @@
 import markdown
 from pykwiki.core import conf, Post
 
-POST_RE = r'(\[\[([a-zA-Z0-9]+.*?)\]\])' 
+POST_RE = r'(\[\[([a-zA-Z0-9]+.*?)\]\])'
 SEC_START_RE = r'(\{section:(.*?)\})'
 SEC_END_RE = r'(\{endsection\})'
 
@@ -33,7 +33,7 @@ class PostPattern(markdown.inlinepatterns.Pattern):
 
         # For [[page:link]]
         if action == 'link':
-            url = '%s/%s'%(conf.web_prefix, 
+            url = '%s/%s'%(conf.web_prefix,
                 post.replace(conf.source_ext, conf.target_ext))
             el = markdown.util.etree.Element("a")
             el.set('href', url)
@@ -53,7 +53,7 @@ class PostPattern(markdown.inlinepatterns.Pattern):
         # For [[page:blurb]]
         if action == 'blurb':
             return pg.blurb
-        
+
         # For [[page:title]]
         if action == 'title':
             return pg.title
@@ -62,7 +62,7 @@ class PostPattern(markdown.inlinepatterns.Pattern):
         if action == 'section':
             if not extra:
                 return 'No section name given'
-            sec = pg.get_section(extra, raw=False) 
+            sec = pg.get_section(extra, raw=False)
             if not sec:
                 return 'Cannot find section: %s'%(extra)
             el = markdown.util.etree.Element("div")

--- a/pykwiki/ext/tpl.py
+++ b/pykwiki/ext/tpl.py
@@ -43,8 +43,8 @@ class TPLExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):
         md.preprocessors.add('pykwiki.tpl', TPLPreprocessor(md), '_begin')
 
-def makeExtension(configs={}):
-    return TPLExtension(configs=configs)
+def makeExtension(**kwargs):
+    return TPLExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest

--- a/pykwiki/ext/tpl.py
+++ b/pykwiki/ext/tpl.py
@@ -28,14 +28,14 @@ class TPLPreprocessor(markdown.preprocessors.Preprocessor):
 
             if not tpl.endswith(conf.template_ext):
                 tpl = tpl + conf.template_ext
-            
+
             d = {}
             if args:
-                d = yaml.load(args)           
-            
+                d = yaml.load(args)
+
             html = render_tpl(tpl, **d)
-            text = pat.sub(html, text, 1)        
- 
+            text = pat.sub(html, text, 1)
+
         return text.split('\n')
 
 class TPLExtension(markdown.Extension):

--- a/pykwiki/ext/uml.py
+++ b/pykwiki/ext/uml.py
@@ -5,7 +5,6 @@ import jinja2
 import re
 
 UML_RE = r'^(\{uml\})(.+?)(\{enduml\})'
-PLANT_UML_CONFIGS = {}
 
 class UMLPreprocessor(markdown.preprocessors.Preprocessor):
 
@@ -45,9 +44,8 @@ class UMLExtension(markdown.Extension):
         md.plant_options = self.config
         md.preprocessors.add('pykwiki.uml', UMLPreprocessor(md), '_begin')
 
-def makeExtension(**configs):
-    PLANT_UML_CONFIGS = configs
-    return UMLExtension(**configs)
+def makeExtension(**kwargs):
+    return UMLExtension(**kwargs)
 
 if __name__ == "__main__":
     import doctest

--- a/pykwiki/ext/uml.py
+++ b/pykwiki/ext/uml.py
@@ -18,8 +18,8 @@ class UMLPreprocessor(markdown.preprocessors.Preprocessor):
         except:
             print("WARNING: Plantuml not installed for this python version: ext.uml disabled.")
             return lines
-    
-        
+
+
         text = '\n'.join(lines)
         pat = re.compile(UML_RE, re.DOTALL|re.M)
         ms = pat.findall(text)
@@ -31,8 +31,8 @@ class UMLPreprocessor(markdown.preprocessors.Preprocessor):
         for m in ms:
             uml = m[1]
             url = puml.get_url(uml)
-            text = pat.sub('<img src="%s"/>'%(url), text, 1)  
- 
+            text = pat.sub('<img src="%s"/>'%(url), text, 1)
+
         return text.split('\n')
 
 class UMLExtension(markdown.Extension):


### PR DESCRIPTION
Adds support for YAML frontmatter separated by `---`.

Since the metadata is already YAML, may as well support the commonly used delimiter.

This should be merged after my other PR.